### PR TITLE
Ignore replica errors when applying migrations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 SETUP_INFO = dict(
     name = 'infi.clickhouse_orm',
-    version = '2.1.0.post11',
+    version = '2.1.0.post12',
     author = 'James Greenhill',
     author_email = 'fuziontech@gmail.com',
 


### PR DESCRIPTION
CREATE TABLE IF NOT EXISTS still raises errors if replicas exist, like
following:

```
E           infi.clickhouse_orm.database.ServerError: Replica /clickhouse/prod/tables/noshard/posthog.infi_clickhouse_orm_migrations/replicas/ch1-01 already exists (version 21.7.3.14 (official build)) (253)
```

This ignores these errors.
