### PR TITLE
Replicate orm migration history correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 SETUP_INFO = dict(
     name = 'infi.clickhouse_orm',
-    version = '2.1.0.post11',
+    version = '2.1.0.post13',
     author = 'James Greenhill',
     author_email = 'fuziontech@gmail.com',
 

--- a/src/infi/clickhouse_orm/engines.py
+++ b/src/infi/clickhouse_orm/engines.py
@@ -104,7 +104,7 @@ class MergeTree(Engine):
     def _build_sql_params(self, db):
         params = []
         if self.replica_name:
-            params += ["'%s'" % self.replica_table_path, "'%s'" % self.replica_name]
+            params += ["'%s'" % self.replica_table_path.format(db_name=db.db_name), "'%s'" % self.replica_name]
 
         # In ClickHouse 1.1.54310 custom partitioning key was introduced
         # https://clickhouse.tech/docs/en/table_engines/custom_partitioning_key/

--- a/src/infi/clickhouse_orm/migrations.py
+++ b/src/infi/clickhouse_orm/migrations.py
@@ -283,7 +283,7 @@ class MigrationHistory(Model):
     engine = MergeTree(
         "applied",
         ("package_name", "module_name"),
-        replica_table_path="/clickhouse/prod/tables/noshard/posthog.infi_clickhouse_orm_migrations",
+        replica_table_path="/clickhouse/{db_name}/tables/noshard/posthog.infi_clickhouse_orm_migrations",
         replica_name="{replica}-{shard}",
     )
 


### PR DESCRIPTION
The path passed needs to be unique, which doesn't work if you try to run
multiple databases (e.g. test and develop) ones at the same time. This
fixes the build in posthog/posthog and makes it possible to run tests
locally again.
