### PR TITLE
Support altinity cloud when fetching server version

### DIFF
--- a/src/infi/clickhouse_orm/database.py
+++ b/src/infi/clickhouse_orm/database.py
@@ -410,6 +410,8 @@ class Database(object):
         except ServerError as e:
             logger.exception('Cannot determine server version (%s), assuming 1.1.0', e)
             ver = '1.1.0'
+        # :TRICKY: Altinity cloud uses a non-numeric suffix for the version, which this removes.
+        ver = re.sub(r"[.\D]+$", '', ver)
         return tuple(int(n) for n in ver.split('.')) if as_tuple else ver
 
     def _is_existing_database(self):


### PR DESCRIPTION
SELECT version() currently returns `21.8.13.1.altinitystable` on our demo environment which blows up.

This PR makes it so we strip out the non-numeric suffic on the version.

Related charts PR: https://github.com/PostHog/charts-clickhouse/pull/276