### PR TITLE
fix(sharding): Distributed migrations table

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 SETUP_INFO = dict(
     name = 'infi.clickhouse_orm',
-    version = '2.1.0.post15',
+    version = '2.1.0.post16',
     author = 'James Greenhill',
     author_email = 'fuziontech@gmail.com',
 

--- a/src/infi/clickhouse_orm/database.py
+++ b/src/infi/clickhouse_orm/database.py
@@ -81,7 +81,8 @@ class Database(object):
     '''
 
     def __init__(self, db_name, db_url='http://localhost:8123/',
-                 username=None, password=None, readonly=False, autocreate=True,
+                 username=None, password=None, cluster=None,
+                 readonly=False, autocreate=True,
                  timeout=60, verify_ssl_cert=True, log_statements=False):
         '''
         Initializes a database instance. Unless it's readonly, the database will be
@@ -91,6 +92,7 @@ class Database(object):
         - `db_url`: URL of the ClickHouse server.
         - `username`: optional connection credentials.
         - `password`: optional connection credentials.
+        - `cluster`: optional cluster to create tables on
         - `readonly`: use a read-only connection.
         - `autocreate`: automatically create the database if it does not exist (unless in readonly mode).
         - `timeout`: the connection timeout in seconds.
@@ -99,6 +101,7 @@ class Database(object):
         '''
         self.db_name = db_name
         self.db_url = db_url
+        self.cluster = cluster
         self.readonly = False
         self.timeout = timeout
         self.request_session = requests.Session()

--- a/src/infi/clickhouse_orm/engines.py
+++ b/src/infi/clickhouse_orm/engines.py
@@ -224,9 +224,9 @@ class Distributed(Engine):
     See full documentation here
     https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
     """
-    def __init__(self, cluster, table=None, sharding_key=None):
+    def __init__(self, cluster=None, table=None, sharding_key=None):
         """
-        - `cluster`: what cluster to access data from
+        - `cluster`: what cluster to access data from. Defaults to db.cluster
         - `table`: underlying table that actually stores data.
         If you are not specifying any table here, ensure that it can be inferred
         from your model's superclass (see models.DistributedModel.fix_engine_table)
@@ -259,7 +259,11 @@ class Distributed(Engine):
             raise ValueError("Cannot create {} engine: specify an underlying table".format(
                 self.__class__.__name__))
 
-        params = ["`%s`" % p for p in [self.cluster, db.db_name, self.table_name]]
+        if self.cluster is None and db.cluster is None:
+            raise ValueError("Cannot create engine: specify a cluster")
+
+        cluster = self.cluster if self.cluster is not None else db.cluster
+        params = ["`%s`" % p for p in [cluster, db.db_name, self.table_name]]
         if self.sharding_key:
             params.append(self.sharding_key)
         return params

--- a/src/infi/clickhouse_orm/models.py
+++ b/src/infi/clickhouse_orm/models.py
@@ -7,7 +7,7 @@ from logging import getLogger
 import pytz
 
 from .fields import Field, StringField
-from .utils import parse_tsv, NO_VALUE, get_subclass_names, arg_to_sql, unescape
+from .utils import on_cluster, parse_tsv, NO_VALUE, get_subclass_names, arg_to_sql, unescape
 from .query import QuerySet
 from .funcs import F
 from .engines import Merge, Distributed
@@ -352,7 +352,7 @@ class Model(metaclass=ModelBase):
         '''
         Returns the SQL statement for creating a table for this model.
         '''
-        parts = ['CREATE TABLE IF NOT EXISTS `%s`.`%s` (' % (db.db_name, cls.table_name())]
+        parts = ['CREATE TABLE IF NOT EXISTS `%s`.`%s` %s (' % (db.db_name, cls.table_name(), on_cluster(db))]
         # Fields
         items = []
         for name, field in cls.fields().items():

--- a/src/infi/clickhouse_orm/utils.py
+++ b/src/infi/clickhouse_orm/utils.py
@@ -155,6 +155,12 @@ def get_subclass_names(locals, base_class):
     from inspect import isclass
     return [c.__name__ for c in locals.values() if isclass(c) and issubclass(c, base_class)]
 
+def on_cluster(db):
+    if db.cluster is not None:
+        return "ON CLUSTER '{}'".format(db.cluster)
+    else:
+        return ''
+
 
 class NoValue:
     '''


### PR DESCRIPTION
Part of https://github.com/PostHog/posthog/issues/8652

clickhouse-operator only creates tables backed by `Distributed` engine onto new shards, see https://github.com/Altinity/clickhouse-operator/issues/903 for more details. We automatically create PostHog tables manually (see https://github.com/PostHog/posthog/pull/8912) but clickhouse migrations also need to be runnable no matter what clickhouse node we hit.