### PR TITLE
Base `MigrationHistoryReplicated` path on database and table names

### DIFF
--- a/src/infi/clickhouse_orm/migrations.py
+++ b/src/infi/clickhouse_orm/migrations.py
@@ -298,7 +298,7 @@ class MigrationHistoryReplicated(Model):
     engine = MergeTree(
         "applied",
         ("package_name", "module_name"),
-        replica_table_path="/clickhouse/prod/tables/noshard/posthog.infi_clickhouse_orm_migrations",
+        replica_table_path="/clickhouse/prod/tables/noshard/{database}/{table}",
         replica_name="{replica}-{shard}",
     )
 


### PR DESCRIPTION
## Problem

```
DB::Exception: Table default.infi_clickhouse_orm_migrations_distributed doesn't exist.
```

The hardcoded Zookeeper path (`replica_table_path`) made it impossible to use a single cluster for both development (database `default`) and testing (`posthog_test`). The above error popped up for instance when trying to run `DEBUG=1 ./bin/migrate` having already ran `yarn --cwd plugin-server setup:test`.

## Fix

Now the path uses ClickHouse best practices (`{database}/{table}` syntax), as per [Data Replication docs](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication/#creating-replicated-tables), which avoids the nasty collision of paths.

## Risk

The docs do say:

> The path in Zookeeper cannot be changed, and when the table is renamed, the macros will expand into a different path, the table will refer to a path that does not exist in Zookeeper, and will go into read-only mode.

This particular change appears safe though, as – to the extent of my knowledge – it cannot _change_ existing configurations, the ORM only evaluating `replica_table_path` on `Database.create_table()` and never updating it for tables that already exist.

I tested the change locally by migrating CH with the current `master` version of this package and then doing it again with the fix – didn't experience any issue. No issues when running both `DEBUG=1 ./bin/migrate` and `yarn --cwd plugin-server setup:test` on one cluster either of course (anymore).

## Context

See [internal Slack thread(s)](https://posthog.slack.com/archives/C0374DA782U/p1652705818741999).
And thanks @tiina303 for looking into this too!