### PR TITLE
Bump package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 SETUP_INFO = dict(
     name = 'infi.clickhouse_orm',
-    version = '2.1.0.post18',
+    version = '2.1.0.post19',
     author = 'James Greenhill',
     author_email = 'fuziontech@gmail.com',
 


### PR DESCRIPTION
Even when checkouting from git, pip uses the package version to do cache-busting to some extent. I haven't received the latest version, this should fix it.